### PR TITLE
 changing the python setup

### DIFF
--- a/R/convert.R
+++ b/R/convert.R
@@ -10,21 +10,36 @@ convert_pdf_text <-function(pdf_filenames){
 
   pdf_list<- as.list(pdf_filenames)
 
+  py_path <- system.file("python", package = 'mintEMU' )
+  py_env_path <- system.file("python/pyvenv", package = 'mintEMU' )
+  pyf_path <- system.file("python","extract-text-pdf-python.py", package = 'mintEMU' )
+
+
   # Create virtual environment
-  if ( !file.exists(here::here("inst/python", "pyvenv") )) {
-    reticulate::install_python(version = '3.9.7')
-    reticulate::virtualenv_create(envname = here::here("inst/python","pyvenv"),
-                                  version = "3.9.7")
-    reticulate::py_install("PyMuPDF == 1.21.0", envname = here::here("inst/python","pyvenv"))
+  if (!file.exists(py_env_path)) {
+    if (is.null(reticulate::py_version())) {
+      t <-  try(reticulate::use_python_version("3.9:latest", required = TRUE))
+
+    if (inherits(t, "try-error"))
+        reticulate::install_python(version = "3.9:latest")
+    }
+    else if (reticulate::py_version() != "3.9" )
+      stop("An incompatible Python version has been initialised. Restart R session to continue.")
+
+
+    py_env_path <- file.path(py_path, "pyvenv")
+    reticulate::virtualenv_create(envname = py_env_path,
+                                  version = "3.9:latest")
+    reticulate::py_install("PyMuPDF == 1.21.0", envname = py_env_path)
   }
 
   # Activate the virtual environment for python
-  reticulate::use_virtualenv(here::here("inst/python","pyvenv"))
+  reticulate::use_virtualenv(py_env_path)
 
   # Load python script with functions to extract texts
-  reticulate::source_python(here::here("inst/python","extract-text-pdf-python.py"))
+  reticulate::source_python(pyf_path)
 
-  text_list <- convert_pdf(pdf_list) %>% unlist()
+  text_list <- convert_pdf(pdf_list) |> unlist()
 
   text_list
 }

--- a/renv.lock
+++ b/renv.lock
@@ -9,6 +9,14 @@
     ]
   },
   "Packages": {
+    "BH": {
+      "Package": "BH",
+      "Version": "1.81.0-1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "68122010f01c4dcfbe58ce7112f2433d",
+      "Requirements": []
+    },
     "DBI": {
       "Package": "DBI",
       "Version": "1.1.3",
@@ -24,6 +32,17 @@
       "Repository": "CRAN",
       "Hash": "c4bc79931eab19f1553b31b744aa5ac1",
       "Requirements": []
+    },
+    "LDAvis": {
+      "Package": "LDAvis",
+      "Version": "0.3.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "a8e3346fc74f90602c0d78a29265ad5c",
+      "Requirements": [
+        "RJSONIO",
+        "proxy"
+      ]
     },
     "MASS": {
       "Package": "MASS",
@@ -65,6 +84,14 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "45f0398006e83a5b10b72a90663d8d8c",
+      "Requirements": []
+    },
+    "RJSONIO": {
+      "Package": "RJSONIO",
+      "Version": "1.3-1.8",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "cd79d1874fb20217463451f8c310c526",
       "Requirements": []
     },
     "Rcpp": {
@@ -1296,6 +1323,14 @@
         "vctrs"
       ]
     },
+    "modeltools": {
+      "Package": "modeltools",
+      "Version": "0.2-23",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "f5a957c02222589bdf625a67be68b2a9",
+      "Requirements": []
+    },
     "munsell": {
       "Package": "munsell",
       "Version": "0.5.0",
@@ -1506,6 +1541,14 @@
         "magrittr",
         "rlang"
       ]
+    },
+    "proxy": {
+      "Package": "proxy",
+      "Version": "0.4-27",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "e0ef355c12942cf7a6b91a6cfaea8b3e",
+      "Requirements": []
     },
     "ps": {
       "Package": "ps",
@@ -2339,6 +2382,20 @@
         "xfun"
       ]
     },
+    "tm": {
+      "Package": "tm",
+      "Version": "0.7-11",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "625329dd66ec8e8fbeb5ea6003e9be0a",
+      "Requirements": [
+        "BH",
+        "NLP",
+        "Rcpp",
+        "slam",
+        "xml2"
+      ]
+    },
     "tokenizers": {
       "Package": "tokenizers",
       "Version": "0.3.0",
@@ -2349,6 +2406,18 @@
         "Rcpp",
         "SnowballC",
         "stringi"
+      ]
+    },
+    "topicmodels": {
+      "Package": "topicmodels",
+      "Version": "0.2-14",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "95bbc3bd6826656ae5e73dfc84da3fd8",
+      "Requirements": [
+        "modeltools",
+        "slam",
+        "tm"
       ]
     },
     "tzdb": {


### PR DESCRIPTION
Hi @cforgaci  and @Selkubi ,

I have adapted how the python virtual environment is created and used, so that it can be used from both users' and developers perspective. I have made use of `system.file()` function to achieve that. 

Based on the `system.file()` function behaviour when using `devtools` (see [here](https://r-pkgs.org/data.html#sec-data-system-file)), It might be sufficient to call the virtual environment that already exists in the `inst/` folder. 

Note, that I have relaxed the python version requirements from `3.9.7` to `3.9:latest`, as I cannot check which version is being used beyond order of major patches (i.e. `3.9` in this case). 

If you have already `inst/pyvenv` package - I would suggest to remove it as it might cause incompatibilities is you have a Python version installed that is higher than `3.9.7`.

If you test whether the solution works - I would test it at least twice - once to see if it creates the virtual env, the second time to see if it uses the venv that is already created.  

Please let me know if you need more explanations.
