### PR TITLE
added dependencies to the DESCRIPTION file

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,10 +28,52 @@ Imports:
     ggplot2,
     here,
     reticulate,
-    tidygeocoder
+    tidygeocoder,
+    base (>= 4.2.0),
+    bs4Dash (>= 2.2.1),
+    dplyr (>= 1.1.2),
+    furrr (>= 0.3.1),
+    future (>= 1.32.0),
+    git2r (>= 0.32.0),
+    grid (>= 4.2.0),
+    jsonlite (>= 1.8.5),
+    kableExtra (>= 1.3.4),
+    knitr (>= 1.43),
+    ldatuning (>= 1.0.2),
+    LDAvis (>= 0.3.2),
+    leaflet (>= 2.1.2),
+    plyr (>= 1.8.8),
+    purrr (>= 1.0.1),
+    readr (>= 2.1.4),
+    readxl (>= 1.4.2),
+    renv (>= 0.16.0),
+    rlang (>= 1.1.1),
+    rmarkdown (>= 2.22),
+    rrtools (>= 0.1.5),
+    shiny (>= 1.7.4),
+    shinyjs (>= 2.1.0),
+    slider (>= 0.3.0),
+    SnowballC (>= 0.7.1),
+    stringi (>= 1.7.12),
+    stringr (>= 1.5.0),
+    textstem (>= 0.1.4),
+    thematic (>= 0.1.2.1),
+    tibble (>= 3.2.1),
+    tidyr (>= 1.3.0),
+    tidyselect (>= 1.2.0),
+    tidytext (>= 0.4.1),
+    tidyverse (>= 2.0.0),
+    tools (>= 4.2.0),
+    topicmodels (>= 0.2-14),
+    utils (>= 4.2.0),
+    widyr (>= 0.1.5),
+    wordcloud2 (>= 0.2.1)
 Suggests: 
     devtools,
-    testthat (>= 3.0.0)
+    testthat (>= 3.0.0),
+    usethis
+Remotes:
+  benmarwick/rrtools    
 Config/testthat/edition: 3
 Depends: 
     R (>= 2.10)

--- a/renv.lock
+++ b/renv.lock
@@ -1,6 +1,6 @@
 {
   "R": {
-    "Version": "4.3.0",
+    "Version": "4.2.0",
     "Repositories": [
       {
         "Name": "CRAN",
@@ -33,12 +33,23 @@
       "Hash": "c4bc79931eab19f1553b31b744aa5ac1",
       "Requirements": []
     },
-    "MASS": {
-      "Package": "MASS",
-      "Version": "7.3-58.4",
+    "LDAvis": {
+      "Package": "LDAvis",
+      "Version": "0.3.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "a3142b2a022b8174ca675bc8b80cdc4e",
+      "Hash": "a8e3346fc74f90602c0d78a29265ad5c",
+      "Requirements": [
+        "RJSONIO",
+        "proxy"
+      ]
+    },
+    "MASS": {
+      "Package": "MASS",
+      "Version": "7.3-60",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "a56a6365b3fa73293ea8d084be0d9bb0",
       "Requirements": []
     },
     "Matrix": {
@@ -73,6 +84,14 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "45f0398006e83a5b10b72a90663d8d8c",
+      "Requirements": []
+    },
+    "RJSONIO": {
+      "Package": "RJSONIO",
+      "Version": "1.3-1.8",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "cd79d1874fb20217463451f8c310c526",
       "Requirements": []
     },
     "Rcpp": {
@@ -113,10 +132,10 @@
     },
     "Rmpfr": {
       "Package": "Rmpfr",
-      "Version": "0.9-2",
+      "Version": "0.9-3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "51640c8a9f57c61be613afe396c84176",
+      "Hash": "836d3666226a1ad1e0128a2029ff4079",
       "Requirements": [
         "gmp"
       ]
@@ -303,6 +322,14 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "3f038e5ac7f41d4ac41ce658c85e3042",
+      "Requirements": []
+    },
+    "clisymbols": {
+      "Package": "clisymbols",
+      "Version": "1.2.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "96c01552bfd5661b9bbdefbc762f4bcd",
       "Requirements": []
     },
     "codetools": {
@@ -1548,6 +1575,14 @@
         "rlang"
       ]
     },
+    "proxy": {
+      "Package": "proxy",
+      "Version": "0.4-27",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "e0ef355c12942cf7a6b91a6cfaea8b3e",
+      "Requirements": []
+    },
     "ps": {
       "Package": "ps",
       "Version": "1.7.5",
@@ -1828,6 +1863,32 @@
       "Repository": "CRAN",
       "Hash": "1de7ab598047a87bba48434ba35d497d",
       "Requirements": []
+    },
+    "rrtools": {
+      "Package": "rrtools",
+      "Version": "0.1.5",
+      "Source": "GitHub",
+      "RemoteType": "github",
+      "RemoteHost": "api.github.com",
+      "RemoteRepo": "rrtools",
+      "RemoteUsername": "benmarwick",
+      "RemoteRef": "HEAD",
+      "RemoteSha": "acbae5ee9f9ad099ffa645b2b64a6966e40933b7",
+      "Hash": "99234187afbbb50770a4c8d28b3e5f32",
+      "Requirements": [
+        "clisymbols",
+        "crayon",
+        "devtools",
+        "git2r",
+        "glue",
+        "here",
+        "httr",
+        "jsonlite",
+        "rmarkdown",
+        "rstudioapi",
+        "usethis",
+        "whisker"
+      ]
     },
     "rstudioapi": {
       "Package": "rstudioapi",


### PR DESCRIPTION
adapted the list with:
```rrtools::add_dependencies_to_description()```

Added the reference to `rrtools` in the `Remotes` section, as suggested in the [`renv` package vignette](https://rstudio.github.io/renv/articles/packages.html):

```
Remotes:
  benmarwick/rrtools    
```

